### PR TITLE
Hash the password with crypt

### DIFF
--- a/VirtualBox/etc/e-smith/events/actions/nethserver-virtualbox-create-user-vboxweb
+++ b/VirtualBox/etc/e-smith/events/actions/nethserver-virtualbox-create-user-vboxweb
@@ -25,6 +25,6 @@ PASSWORD=$(perl -MNethServer::Password -e "print NethServer::Password::store(\"v
 if /usr/bin/getent passwd vboxweb > /dev/null; then
     exit 0
 else
-    /usr/sbin/useradd -m -p $(openssl passwd -1 $PASSWORD) vboxweb
+    /usr/sbin/useradd -m -p $(openssl passwd -crypt $PASSWORD) vboxweb
     /usr/sbin/usermod -a -G vboxusers vboxweb
 fi


### PR DESCRIPTION
The password hash with md5 could fail and make some issues, since the service is restricted to localhost, we could hash with crypt